### PR TITLE
fix Error when reading an empty numeric record

### DIFF
--- a/gtool3/format.py
+++ b/gtool3/format.py
@@ -70,8 +70,16 @@ class __gtHdrFmt__(object):
                 return ''
 
         else:
-            return list( self.fmt[ k ][0]( b.strip() ) for b in values )
-            #return list( self.fmt[ k ][0]( b.strip() ) for b in np.unique( values ) )
+            l = []
+            for b in values:
+                try:
+                    v = self.fmt[k][0](b.strip())
+                except:
+                    print('Warning: cannot cast {}:{} to {}, replace with empty string.'.format(
+                        k, b, self.fmt[k][0]))
+                    v = ""
+                l.append(v)
+            return l
 
 
     @property


### PR DESCRIPTION
Fixed an error when reading an empty numeric record in header of grid data (e.g. GTAXLOC.OCLATTPT256).

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ytakano/miniconda3/lib/python3.8/site-packages/gtool3/gtool3.py", line 231, in vars
    varName     = chunk.header['ITEM']
  File "/Users/ytakano/miniconda3/lib/python3.8/site-packages/gtool3/chunk.py", line 68, in header
    return __gtHdr__( self.__header__[None,:] )
  File "/Users/ytakano/miniconda3/lib/python3.8/site-packages/gtool3/header.py", line 44, in __init__
    self.dict   = OrderedDict(
  File "/Users/ytakano/miniconda3/lib/python3.8/site-packages/gtool3/header.py", line 45, in <genexpr>
    ( k, self.cast( k, v ) ) for k, v in self.asdict.items()
  File "/Users/ytakano/miniconda3/lib/python3.8/site-packages/gtool3/format.py", line 65, in cast
    return self.fmt[ k ][0]( values[0].strip() )
ValueError: invalid literal for int() with base 10: b''
```